### PR TITLE
Use sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *_flymake.hs
 dist/*
+cabal.sandbox.config
+.cabal-sandbox/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*_flymake.hs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *_flymake.hs
+dist/*

--- a/sql-server-gen.cabal
+++ b/sql-server-gen.cabal
@@ -52,7 +52,8 @@ cabal-version:       >=1.10
 library
   -- Modules exported by the library.
   exposed-modules:     Database.SqlServer.Types.Database,
-                       Database.SqlServer.Types.Sequence               
+                       Database.SqlServer.Types.Sequence,
+                       Database.SqlServer.Types.Identifiers           
 
   ghc-options:         -Wall
   
@@ -83,5 +84,6 @@ Test-Suite tests
   default-language:     Haskell2010
   build-depends:        base >=4.8 && <4.9,
                         sql-server-gen,
-                        hspec >= 2.1.7
+                        hspec >= 2.1.7,
+                        containers >= 0.5.6.2
                                     

--- a/src/Database/SqlServer/Types/DataTypes.hs
+++ b/src/Database/SqlServer/Types/DataTypes.hs
@@ -137,8 +137,8 @@ data PrecisionStorage = PrecisionStorage Int
 
 instance Arbitrary PrecisionStorage where
   arbitrary = do
-    precision <- choose(1,53)
-    return (PrecisionStorage precision)
+    p <- choose(1,53)
+    return (PrecisionStorage p)
 
 renderPrecisionStorage :: PrecisionStorage -> Doc
 renderPrecisionStorage (PrecisionStorage n) = lparen <> int n <> rparen
@@ -147,8 +147,8 @@ data FractionalSecondsPrecision = FractionalSecondsPrecision Int
 
 instance Arbitrary FractionalSecondsPrecision where
   arbitrary = do
-    precision <- choose (0,7)
-    return (FractionalSecondsPrecision precision)
+    p <- choose (0,7)
+    return (FractionalSecondsPrecision p)
 
 renderFractionalSecondsPrecision :: FractionalSecondsPrecision -> Doc
 renderFractionalSecondsPrecision (FractionalSecondsPrecision n) = lparen <> int n <> rparen

--- a/src/Database/SqlServer/Types/Identifiers.hs
+++ b/src/Database/SqlServer/Types/Identifiers.hs
@@ -6,11 +6,16 @@ import Test.QuickCheck
 import Control.Monad (liftM2)
 import Text.PrettyPrint
 
+import Data.Char (toUpper)
+
 -- https://msdn.microsoft.com/en-us/subscriptions/downloads/ms175874
 newtype RegularIdentifier = RegularIdentifier
                             {
                               unwrap :: String
-                            } deriving (Eq,Ord)
+                            } deriving (Ord)
+
+instance Eq RegularIdentifier where
+  a == b = (map toUpper $ unwrap a) == (map toUpper $ unwrap b)
 
 renderRegularIdentifier :: RegularIdentifier -> Doc
 renderRegularIdentifier (RegularIdentifier x) = text x

--- a/src/Database/SqlServer/Types/Identifiers.hs
+++ b/src/Database/SqlServer/Types/Identifiers.hs
@@ -5,6 +5,7 @@ import Database.SqlServer.Types.Reserved (isReserved)
 import Test.QuickCheck
 import Control.Monad (liftM2)
 import Text.PrettyPrint
+import Data.Ord
 
 import Data.Char (toUpper)
 
@@ -12,10 +13,16 @@ import Data.Char (toUpper)
 newtype RegularIdentifier = RegularIdentifier
                             {
                               unwrap :: String
-                            } deriving (Ord)
+                            } 
+
+upCase :: String -> String
+upCase = map toUpper
 
 instance Eq RegularIdentifier where
-  a == b = (map toUpper $ unwrap a) == (map toUpper $ unwrap b)
+  a == b = (upCase $ unwrap a) == (upCase $ unwrap b)
+
+instance Ord RegularIdentifier where
+  compare = comparing (upCase . unwrap)
 
 renderRegularIdentifier :: RegularIdentifier -> Doc
 renderRegularIdentifier (RegularIdentifier x) = text x

--- a/src/Database/SqlServer/Types/Procedure.hs
+++ b/src/Database/SqlServer/Types/Procedure.hs
@@ -12,6 +12,7 @@ import Test.QuickCheck
 import Data.DeriveTH
 import Text.PrettyPrint
 import Control.Monad
+import Data.Ord
 
 import qualified Data.Set as S
 
@@ -28,7 +29,7 @@ derive makeArbitrary ''ProcedureOption
 
 type ProcedureOptions = S.Set ProcedureOption
 
-newtype ParameterIdentifier = ParameterIdentifier { unwrapP :: RegularIdentifier }
+newtype ParameterIdentifier = ParameterIdentifier { unwrapP :: RegularIdentifier } deriving (Ord,Eq)
 
 derive makeArbitrary ''ParameterIdentifier
 
@@ -45,6 +46,12 @@ data Parameter = Parameter
 instance NamedEntity Parameter where
   name = unwrapP . parameterName
 
+instance Ord Parameter where
+  compare = comparing parameterName
+
+instance Eq Parameter where
+  a == b = parameterName a == parameterName b
+
 derive makeArbitrary ''Parameter
 
 renderOut :: Bool -> Doc
@@ -54,16 +61,24 @@ renderOut False = empty
 renderParameter :: Parameter -> Doc
 renderParameter p = renderParameterIdentifier (parameterName p) <+> renderDataType (dataType p) <+> renderOut (isOutput p)
 
-newtype Parameters = Parameters { unwrap :: [Parameter] } 
+newtype Parameters = Parameters { unwrap :: S.Set Parameter } 
 
 instance Arbitrary Parameters where
-  arbitrary = liftM Parameters (listOf arbitrary `suchThat` validIdentifiers)
+  arbitrary = do
+    p <- listOf arbitrary `suchThat` validIdentifiers
+    return $ Parameters (S.fromList p)
 
 data ProcedureDefinition = ProcedureDefinition
   {
     procedureName :: RegularIdentifier
   , parameters    :: Parameters
   }
+
+instance Eq ProcedureDefinition where
+  a == b = procedureName a == procedureName b
+
+instance Ord ProcedureDefinition where
+  compare = comparing procedureName
 
 instance NamedEntity ProcedureDefinition where
   name = procedureName
@@ -76,7 +91,7 @@ statementBody = "select 1\n"
 
 renderProcedureDefinition :: ProcedureDefinition -> Doc
 renderProcedureDefinition p = text "CREATE PROCEDURE" <+> renderRegularIdentifier (procedureName p) $+$
-                              hcat (punctuate comma (map renderParameter (unwrap $ parameters p))) <+> text "AS" $+$
+                              hcat (punctuate comma (map renderParameter (S.toList $ unwrap $ parameters p))) <+> text "AS" $+$
                               text statementBody $+$
                               text "GO"
                               

--- a/src/Database/SqlServer/Types/Procedure.hs
+++ b/src/Database/SqlServer/Types/Procedure.hs
@@ -11,7 +11,6 @@ import Database.SqlServer.Types.Properties
 import Test.QuickCheck
 import Data.DeriveTH
 import Text.PrettyPrint
-import Control.Monad
 import Data.Ord
 
 import qualified Data.Set as S

--- a/src/Database/SqlServer/Types/Properties.hs
+++ b/src/Database/SqlServer/Types/Properties.hs
@@ -2,15 +2,9 @@ module Database.SqlServer.Types.Properties where
 
 import Database.SqlServer.Types.Identifiers (RegularIdentifier, unwrap)
 import Database.SqlServer.Types.Reserved (isReserved)
-import Data.Char (toUpper)
-
-import Data.List (nub)
 
 class NamedEntity a where
   name :: a -> RegularIdentifier
-
-uniqueNames :: NamedEntity a => [a] -> Bool
-uniqueNames xs = length xs == length (nub $ map (\x -> map toUpper (unwrap $ name x)) xs)
 
 reserved :: NamedEntity a => a -> Bool
 reserved a = isReserved $ unwrap (name a)
@@ -19,7 +13,7 @@ unReserved :: NamedEntity a => a -> Bool
 unReserved = not . reserved
 
 validIdentifiers :: NamedEntity a => [a] -> Bool
-validIdentifiers xs = all unReserved xs && uniqueNames xs
+validIdentifiers xs = all unReserved xs
 
 
   

--- a/src/Database/SqlServer/Types/Queue.hs
+++ b/src/Database/SqlServer/Types/Queue.hs
@@ -13,6 +13,8 @@ import Data.DeriveTH
 import Data.Word (Word16)
 import Text.PrettyPrint
 import Data.Maybe (isJust)
+import Data.Ord
+import qualified Data.Set as S
 
 -- TODO username support
 data ExecuteAs = Self
@@ -24,7 +26,7 @@ newtype ZeroParamProc = ZeroParamProc { unwrap :: ProcedureDefinition }
 instance Arbitrary ZeroParamProc where
   arbitrary = do
     proc <- arbitrary :: Gen ProcedureDefinition
-    return $ ZeroParamProc (proc { parameters = Parameters [] })
+    return $ ZeroParamProc (proc { parameters = Parameters S.empty })
 
 
 data Activation = Activation
@@ -45,6 +47,13 @@ data QueueDefinition = QueueDefinition
 
 instance NamedEntity QueueDefinition where
   name = queueName
+
+instance Eq QueueDefinition where
+  a == b = queueName a == queueName b
+
+instance Ord QueueDefinition where
+  compare = comparing queueName
+  
 
 derive makeArbitrary ''ExecuteAs
 derive makeArbitrary ''Activation

--- a/src/Database/SqlServer/Types/Sequence.hs
+++ b/src/Database/SqlServer/Types/Sequence.hs
@@ -14,7 +14,7 @@ import Test.QuickCheck
 import Data.DeriveTH
 import Control.Monad
 import Data.Maybe (fromMaybe)
-
+import Data.Ord
 
 data NumericType = TinyInt | SmallInt | Int | BigInt | Decimal | Numeric
 
@@ -42,6 +42,12 @@ data SequenceDefinition = SequenceDefinition
 
 instance NamedEntity SequenceDefinition where
   name = sequenceName
+
+instance Ord SequenceDefinition where
+  compare = comparing sequenceName
+
+instance Eq SequenceDefinition where
+  a == b = sequenceName a == sequenceName b
 
 renderMinValue :: Maybe Integer -> Doc
 renderMinValue Nothing = text "NO MINVALUE"
@@ -80,6 +86,7 @@ numericBounds  _               = Nothing
 boundedMaybeInt :: (Integer,Integer) -> Gen (Maybe Integer)
 boundedMaybeInt x = oneof [liftM Just $ choose x, return Nothing]
 
+-- Bug.  If used for min value, value can't be upper bound (e.g. min value 255 for TinyInt)
 arbitraryValue :: Maybe NumericType -> Gen (Maybe Integer)
 arbitraryValue Nothing = arbitraryValue (Just Int)
 arbitraryValue (Just TinyInt)  = boundedMaybeInt (0,255)

--- a/src/Database/SqlServer/Types/Sequence.hs
+++ b/src/Database/SqlServer/Types/Sequence.hs
@@ -129,13 +129,9 @@ validIncrementBy' x       min' max' incr' = maybe True (\incr -> abs incr <= dif
     max'' = fromMaybe upper max'
     diff  = abs (max'' - min'')
 
-validSequenceName :: RegularIdentifier -> Bool
-validSequenceName (RegularIdentifier (x:_)) = x /= '#'
-validSequenceName _                         = error "instance of arbitrary for new type declaration should mean this can not happen"
-
 instance Arbitrary SequenceDefinition where
   arbitrary = do
-    nm <- arbitrary `suchThat` validSequenceName
+    nm <- arbitrary
     dataType <- arbitrary
     minV <- arbitraryValue dataType
     maxV <- arbitraryValue dataType `suchThat` (greaterThanMin minV)

--- a/src/Database/SqlServer/Types/Table.hs
+++ b/src/Database/SqlServer/Types/Table.hs
@@ -24,6 +24,7 @@ import Database.SqlServer.Types.Collations (renderCollation)
 import Test.QuickCheck
 import Control.Monad
 import Text.PrettyPrint
+import Data.Ord
 
 import Data.DeriveTH
 
@@ -35,6 +36,12 @@ data TableDefinition = TableDefinition
                tableName    :: RegularIdentifier
              , columnDefinitions :: ColumnDefinitions
              }
+
+instance Eq TableDefinition where
+  a == b = tableName a == tableName b
+
+instance Ord TableDefinition where
+  compare = comparing tableName
 
 instance NamedEntity TableDefinition where
   name = tableName

--- a/src/Database/SqlServer/Types/Table.hs
+++ b/src/Database/SqlServer/Types/Table.hs
@@ -25,10 +25,11 @@ import Test.QuickCheck
 import Control.Monad
 import Text.PrettyPrint
 import Data.Ord
+import qualified Data.Set as S
 
 import Data.DeriveTH
 
-newtype ColumnDefinitions = ColumnDefinitions [ColumnDefinition]
+newtype ColumnDefinitions = ColumnDefinitions (S.Set ColumnDefinition)
 
 -- https://msdn.microsoft.com/en-us/library/ms174979.aspx
 data TableDefinition = TableDefinition

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,11 +3,23 @@ module Main (main) where
 import Test.Hspec
 
 import Database.SqlServer.Types.Sequence
+import Database.SqlServer.Types.Identifiers
 
-{-
-greaterThanMin :: Maybe Integer -> Maybe Integer -> Bool
-lessThanMax :: Maybe Integer -> Maybe Integer -> Bool
--}
+import qualified Data.Set as S
+
+a :: RegularIdentifier
+a = RegularIdentifier "a"
+
+aCaps :: RegularIdentifier
+aCaps = RegularIdentifier "A"
+
+identifierSpecs :: Spec
+identifierSpecs = do
+  describe "identifiers" $ do
+    it "compare equal even if differing case" $ do
+      a == aCaps `shouldBe` True
+    it "are handled correctly in sets even if differing in case" $ do
+      (S.size (S.fromList [a, aCaps])) `shouldBe` 1
 
 greaterThanMinSpecs :: Spec
 greaterThanMinSpecs = do
@@ -33,5 +45,6 @@ lessThanMaxSpecs = do
 
 main :: IO()
 main = hspec $ do
+  identifierSpecs
   greaterThanMinSpecs
   lessThanMaxSpecs


### PR DESCRIPTION
I'd previously made life difficult for myself by using lists and then enforcing uniqueness later.  With the correct definition of `Eq` and `Ord` for `RegularIdentifier`, I can use `Data.Set` everywhere and make life so much easier.  Woo.
