### PR TITLE
Improve the examples for new users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ An example of use from the REPL (`--` indicates comments not to be entered).
     y
 
     -- Write the alter statements out to a file
-    writeFile "AlterTable.sql" (show y)
+    writeFile "AlterTable.sql" $ asScript y
 
 The goal of this work is to allow you to build an arbitrary database and then an infinite sequence of ALTER statements to permute the database.
 
@@ -89,7 +89,7 @@ If you want to generate an infinite list of tables for your own nefarious purpos
 
     > let tables = generateEntities (GenerateOptions 1 10) :: [Table]
     > let first10 = take 10 tables
-    > saveExamples "myFilename" first10
+    > writeFile "myFilename" $ asScript first10
 
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ A `Database` is the top level container, generating a uniquely named database wi
 
 If you want more control, then you can use `generateEntity` to generate single files.
 
-    > generateEntity (defaultGenerateOptions { size = 10, seed = 22 }) :: User
+    > generateEntity (defaultGenerateOptions 10 22) :: User
 
 If you want to generate an infinite list of tables for your own nefarious purposes then you can use `generateEntities`
 
-    > let tables = generateEntities (defaultGenerateOptions { size = 1, seed = 10} ) :: [Table]
+    > let tables = generateEntities (defaultGenerateOptions 1 10) :: [Table]
     > let first10 = take 10 tables
     > writeFile "myFilename" $ asScript first10
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ A `Database` is the top level container, generating a uniquely named database wi
 
 If you want more control, then you can use `generateEntity` to generate single files.
 
-    > generateEntity (GenerateOptions { size = 10, seed = 22 }) :: User
-    
+    > generateEntity (defaultGenerateOptions { size = 10, seed = 22 }) :: User
+
 If you want to generate an infinite list of tables for your own nefarious purposes then you can use `generateEntities`
 
-    > let tables = generateEntities (GenerateOptions 1 10) :: [Table]
+    > let tables = generateEntities (defaultGenerateOptions { size = 1, seed = 10} ) :: [Table]
     > let first10 = take 10 tables
     > writeFile "myFilename" $ asScript first10
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ An example of use from the REPL (`--` indicates comments not to be entered).
     -- View the data by just inspecting y
     y
 
+    -- Write the alter statements out to a file
+    writeFile "AlterTable.sql" (show y)
+
 The goal of this work is to allow you to build an arbitrary database and then an infinite sequence of ALTER statements to permute the database.
 
 # Build instructions

--- a/sql-server-gen.cabal
+++ b/sql-server-gen.cabal
@@ -51,8 +51,7 @@ cabal-version:       >=1.10
 
 library
   -- Modules exported by the library.
-  exposed-modules:     Database.SqlServer.Generator
-                       Database.SqlServer.Create.Database,
+  exposed-modules:     Database.SqlServer.Create.Database,
                        Database.SqlServer.Create.Sequence,
                        Database.SqlServer.Create.Identifier,
                        Database.SqlServer.Create.Procedure,
@@ -76,7 +75,8 @@ library
                        Database.SqlServer.Create.Entity,
                        Database.SqlServer.Create.Value,
                        Database.SqlServer.Alter.Alter,
-                       Database.SqlServer.Alter.Table
+                       Database.SqlServer.Alter.Table,
+                       Database.SqlServer.Generator
 
 
   ghc-options:         -Wall -O2 -fwarn-tabs 

--- a/src/Database/SqlServer/Generator.hs
+++ b/src/Database/SqlServer/Generator.hs
@@ -18,7 +18,7 @@ import Database.SqlServer.Create.Login (Login)
 import Database.SqlServer.Create.Certificate (Certificate)
 import Database.SqlServer.Create.Trigger (Trigger)
 import Database.SqlServer.Create.SecurityPolicy (SecurityPolicy)
-import Database.SqlServer.Create.Database (Database, RenderOptions)
+import Database.SqlServer.Create.Database (Database, RenderOptions, defaultRenderOptions)
 import Database.SqlServer.Create.Entity
 
 import Test.QuickCheck
@@ -44,6 +44,14 @@ data GenerateOptions = GenerateOptions
     size :: Int
   , seed :: Int
   , excludeTypes :: RenderOptions
+  }
+
+defaultGenerateOptions :: GenerateOptions
+defaultGenerateOptions = GenerateOptions
+  {
+    size = undefined
+  , seed = undefined
+  , excludeTypes = defaultRenderOptions
   }
 
 generateEntity :: (Arbitrary a, Entity a) => GenerateOptions -> a

--- a/src/Database/SqlServer/Generator.hs
+++ b/src/Database/SqlServer/Generator.hs
@@ -46,11 +46,11 @@ data GenerateOptions = GenerateOptions
   , excludeTypes :: RenderOptions
   }
 
-defaultGenerateOptions :: GenerateOptions
-defaultGenerateOptions = GenerateOptions
+defaultGenerateOptions :: Int -> Int -> GenerateOptions
+defaultGenerateOptions size' seed' = GenerateOptions
   {
-    size = undefined
-  , seed = undefined
+    size = size'
+  , seed = seed'
   , excludeTypes = defaultRenderOptions
   }
 

--- a/src/Database/SqlServer/Generator.hs
+++ b/src/Database/SqlServer/Generator.hs
@@ -37,7 +37,7 @@ _redundantImport :: (
 _redundantImport = undefined
 
 saveExamples :: (Show a) => FilePath -> [a] -> IO ()
-saveExamples p xs = writeFile p (unlines $ map show xs)
+saveExamples p xs = writeFile p $ unlines $ map show xs
 
 data GenerateOptions = GenerateOptions
   {

--- a/src/Database/SqlServer/Generator.hs
+++ b/src/Database/SqlServer/Generator.hs
@@ -36,8 +36,8 @@ _redundantImport :: (
   )
 _redundantImport = undefined
 
-saveExamples :: (Show a) => FilePath -> [a] -> IO ()
-saveExamples p xs = writeFile p $ unlines $ map show xs
+asScript :: (Show a) => [a] -> String
+asScript a = unlines $ map show a
 
 data GenerateOptions = GenerateOptions
   {


### PR DESCRIPTION
To get the examples working:
- [x] Move Generator to end of library module list and the Database to the start so that cabal repl starts in Database module.
- [x] Remove the square brackets generated from examples (x in example is contained in [])
- [x] Add example of writing generated sql to a file
