### PR TITLE
Add Simple Options

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -44,6 +44,17 @@ setFlag ro s =
   case s of
     "T" -> ro {showTables = False}
     "V" -> ro {showViews = False}
+    "S" -> ro {showSequences = False}
+    "P" -> ro {showProcedures = False}
+    "F" -> ro {showFunctions  = False}
+    "U" -> ro {showUsers = False}
+    "R" -> ro {showRoles = False}
+    "FTC" -> ro {showFullTextCatalog = False}
+    "FTS" -> ro {showFullTextStopList = False}
+    "CRED" -> ro {showCredential = False}
+    "M" -> ro {showMessageType = False}
+    "B" -> ro {showBrokerPriority = False}
+    "PF" -> ro {showPartitionFunction = False}
     _   -> ro
 
 header :: Arguments -> String

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -35,7 +35,11 @@ parseRenderOptions :: String -> RenderOptions
 parseRenderOptions xs = foldl setFlag defaultRenderOptions (splitOn "," xs)
 
 setFlag :: RenderOptions -> String -> RenderOptions
-setFlag = undefined
+setFlag ro s =
+  case s of
+    "T" -> ro {showTables = False}
+    "V" -> ro {showViews = False}
+    _   -> ro
 
 header :: Arguments -> String
 header a = unlines 

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -44,6 +44,17 @@ setFlag ro s =
   case s of
     "T" -> ro {showTables = False}
     "V" -> ro {showViews = False}
+    "S" -> ro {showSequences = False}
+    "P" -> ro {showProcedures = False}
+    "F" -> ro {showFunctions = False}
+    "U" -> ro {showUsers = False}
+    "R" -> ro {showRoles = False}
+    "FTC" -> ro {showFullTextCatalog = False}
+    "FTS" -> ro {showFullTextStopList = False}
+    "CRED" -> ro {showCredential = False}
+    "M" -> ro {showMessageType = False}
+    "B" -> ro {showBrokerPriority = False}
+    "PF" -> ro {showPartitionFunction = False}
     _   -> ro
 
 header :: Arguments -> String

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -5,11 +5,13 @@ import System.Console.CmdArgs
 
 import qualified Database.SqlServer.Generator as D
 import Database.SqlServer.Create.Database
+import Data.List.Split
 
 data Arguments = Arguments
     {
       seed :: Int
     , size :: Int
+    , excludeTypes :: String
     } deriving (Show,Data,Typeable)
 
 msg :: [String]
@@ -17,16 +19,23 @@ msg =  ["More details on the github repo at " ++
         " https://github.com/fffej/sql-server-gen"]
 
 defaultArgs :: Arguments
-defaultArgs = Arguments 
+defaultArgs = Arguments
     {
       seed = def &= help "Seed for random number generator" &= name "s"
     , size = 100 &= help "Size of database (optional)" &= opt (500 :: Int) &= name "n"
+    , excludeTypes = "*" &= help "List of object types to exclude comma seperated" &= name "e"
     } &= summary "SQL Server Schema Generator"
       &= help "Generate arbitrary SQL Server databases"
       &= details msg
 
 convert :: Arguments -> D.GenerateOptions
 convert a = D.GenerateOptions { D.seed = seed a, D.size = size a }
+
+parseRenderOptions :: String -> RenderOptions
+parseRenderOptions xs = foldl setFlag defaultRenderOptions (splitOn "," xs)
+
+setFlag :: RenderOptions -> String -> RenderOptions
+setFlag = undefined
 
 header :: Arguments -> String
 header a = unlines 

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -29,7 +29,12 @@ defaultArgs = Arguments
       &= details msg
 
 convert :: Arguments -> D.GenerateOptions
-convert a = D.GenerateOptions { D.seed = seed a, D.size = size a }
+convert a = D.GenerateOptions
+    {
+      D.seed = seed a
+    , D.size = size a
+    , D.excludeTypes = parseRenderOptions $ excludeTypes a
+    }
 
 parseRenderOptions :: String -> RenderOptions
 parseRenderOptions xs = foldl setFlag defaultRenderOptions (splitOn "," xs)

--- a/sql-server-gen.cabal
+++ b/sql-server-gen.cabal
@@ -126,6 +126,5 @@ executable cli
   build-depends:        base >=4.8 && <4.9,
                         sql-server-gen,
                         transformers >= 0.4.2.0,
-                        cmdargs >= 0.10.13
-
-                        
+                        cmdargs >= 0.10.13,
+                        split >= 0.2.2

--- a/src/Database/SqlServer/Create/Database.hs
+++ b/src/Database/SqlServer/Create/Database.hs
@@ -35,10 +35,22 @@ data RenderOptions = RenderOptions
   {
     showTables :: Bool
   , showViews :: Bool
+  , showSequences :: Bool
+  , showProcedures :: Bool
+  , showFunctions :: Bool
+  , showUsers :: Bool
+  , showRoles :: Bool
+  , showFullTextCatalog :: Bool
+  , showFullTextStopList :: Bool
+  , showCredential :: Bool
+  , showMessageType :: Bool
+  , showBrokerPriority :: Bool
+  , showPartitionFunction :: Bool
   } deriving (Show)
 
 defaultRenderOptions :: RenderOptions
-defaultRenderOptions = RenderOptions True True
+defaultRenderOptions = RenderOptions
+  True True True True True True True True True True True True True
 
 data Database = Database
   {

--- a/src/Database/SqlServer/Create/Database.hs
+++ b/src/Database/SqlServer/Create/Database.hs
@@ -35,10 +35,22 @@ data RenderOptions = RenderOptions
   {
     showTables :: Bool
   , showViews :: Bool
+  , showSequences :: Bool
+  , showProcedures :: Bool
+  , showFunctions :: Bool
+  , showUsers :: Bool
+  , showRoles :: Bool
+  , showFullTextCatalog :: Bool
+  , showFullTextStopList :: Bool
+  , showCredential :: Bool
+  , showMessageType :: Bool
+  , showBrokerPriority :: Bool
+  , showPartitionFunction :: Bool
   } deriving (Show)
 
 defaultRenderOptions :: RenderOptions
-defaultRenderOptions = RenderOptions True True
+defaultRenderOptions = RenderOptions
+  True True True True True True True True True True True True True
 
 data Database = Database
   {
@@ -85,17 +97,17 @@ renderDatabase ro dd =
   renderMasterKey (masterKey dd) $+$
   renderEntitiesIf (showTables ro) (tables dd) $+$
   renderEntitiesIf (showViews ro) (views dd) $+$
-  renderEntitiesIf True (sequences dd) $+$
-  renderEntitiesIf True (procedures dd) $+$
-  renderEntitiesIf True (functions dd) $+$
-  renderEntitiesIf True (users dd) $+$
-  renderEntitiesIf True (roles dd) $+$
-  renderEntitiesIf True (fullTextCatalogs dd) $+$
-  renderEntitiesIf True (fullTextStopLists dd) $+$
-  renderEntitiesIf True (credentials dd) $+$
-  renderEntitiesIf True (messages dd) $+$
-  renderEntitiesIf True (brokerPriorities dd) $+$
-  renderEntitiesIf True (partitionFunctions dd)
+  renderEntitiesIf (showSequences ro) (sequences dd) $+$
+  renderEntitiesIf (showProcedures ro) (procedures dd) $+$
+  renderEntitiesIf (showFunctions ro) (functions dd) $+$
+  renderEntitiesIf (showUsers ro) (users dd) $+$
+  renderEntitiesIf (showRoles ro) (roles dd) $+$
+  renderEntitiesIf (showFullTextCatalog ro) (fullTextCatalogs dd) $+$
+  renderEntitiesIf (showFullTextStopList ro) (fullTextStopLists dd) $+$
+  renderEntitiesIf (showCredential ro) (credentials dd) $+$
+  renderEntitiesIf (showMessageType ro) (messages dd) $+$
+  renderEntitiesIf (showBrokerPriority ro) (brokerPriorities dd) $+$
+  renderEntitiesIf (showPartitionFunction ro) (partitionFunctions dd)
   where
     dbName = renderName dd
 

--- a/src/Database/SqlServer/Generator.hs
+++ b/src/Database/SqlServer/Generator.hs
@@ -18,7 +18,7 @@ import Database.SqlServer.Create.Login (Login)
 import Database.SqlServer.Create.Certificate (Certificate)
 import Database.SqlServer.Create.Trigger (Trigger)
 import Database.SqlServer.Create.SecurityPolicy (SecurityPolicy)
-import Database.SqlServer.Create.Database (Database)
+import Database.SqlServer.Create.Database (Database, RenderOptions)
 import Database.SqlServer.Create.Entity
 
 import Test.QuickCheck
@@ -43,6 +43,7 @@ data GenerateOptions = GenerateOptions
   {
     size :: Int
   , seed :: Int
+  , excludeTypes :: RenderOptions
   }
 
 generateEntity :: (Arbitrary a, Entity a) => GenerateOptions -> a


### PR DESCRIPTION
Adding a rendoption to cli.exe in order to exclude options in the database generated.  This is useful if, for example, a particular object type has  known fault in your SUT.
